### PR TITLE
Add default groceries category to dashboard

### DIFF
--- a/app/src/main/java/com/example/oinkonomics/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/example/oinkonomics/ui/dashboard/DashboardFragment.kt
@@ -23,6 +23,10 @@ import kotlinx.coroutines.launch
 
 class DashboardFragment : Fragment() {
 
+    companion object {
+        private const val DEFAULT_GROCERIES_MAX = 5000.0
+    }
+
     private val budgetCategories = mutableListOf<BudgetCategory>()
     private lateinit var gridLayout: GridLayout
     private lateinit var totalSpentTextView: TextView
@@ -256,7 +260,15 @@ class DashboardFragment : Fragment() {
     private fun loadCategories() {
         val currentUserId = userId ?: return
         viewLifecycleOwner.lifecycleScope.launch {
-            val categories = repository.getBudgetCategories(currentUserId)
+            val categories = repository.getBudgetCategories(currentUserId).toMutableList()
+            if (categories.isEmpty()) {
+                val defaultCategory = repository.createBudgetCategory(
+                    currentUserId,
+                    name = getString(R.string.default_category_name),
+                    maxAmount = DEFAULT_GROCERIES_MAX
+                )
+                categories.add(defaultCategory)
+            }
             budgetCategories.clear()
             budgetCategories.addAll(categories)
             renderCategories()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
   <string name="remove_category_confirmation">Are you sure you want to remove this category?</string>
   <string name="remove">Remove</string>
   <string name="invalid_category_inputs">Please provide a name and numeric amounts.</string>
+  <string name="default_category_name">Groceries</string>
   <!-- AUTH -->
   <string name="login_title">Welcome back</string>
   <string name="register_title">Create your account</string>


### PR DESCRIPTION
## Summary
- ensure the dashboard always has a default "Groceries" budget category with a R5000 limit
- add a localized string for the default category name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff809e9148333bd1f56af7362c708