### PR TITLE
Switch persistence to Room database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     kotlin("android")
+    kotlin("kapt")
 }
 
 android {
@@ -50,6 +51,9 @@ dependencies {
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/oinkonomics/data/BudgetCategory.kt
+++ b/app/src/main/java/com/example/oinkonomics/data/BudgetCategory.kt
@@ -1,9 +1,32 @@
 package com.example.oinkonomics.data
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "budget_categories",
+    foreignKeys = [
+        ForeignKey(
+            entity = User::class,
+            parentColumns = ["id"],
+            childColumns = ["user_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("user_id")]
+)
 data class BudgetCategory(
+    @PrimaryKey(autoGenerate = true)
     var id: Long = 0L,
+    @ColumnInfo(name = "user_id")
     var userId: Long,
+    @ColumnInfo(name = "name")
     var name: String,
+    @ColumnInfo(name = "max_amount")
     var maxAmount: Double,
+    @ColumnInfo(name = "spent_amount", defaultValue = "0")
     var spentAmount: Double = 0.0
 )

--- a/app/src/main/java/com/example/oinkonomics/data/Expense.kt
+++ b/app/src/main/java/com/example/oinkonomics/data/Expense.kt
@@ -1,19 +1,52 @@
 package com.example.oinkonomics.data
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Ignore
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import java.time.LocalDate
 
 /**
  * Represents a single expense entry recorded by the user.
  */
+@Entity(
+    tableName = "expenses",
+    foreignKeys = [
+        ForeignKey(
+            entity = User::class,
+            parentColumns = ["id"],
+            childColumns = ["user_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = BudgetCategory::class,
+            parentColumns = ["id"],
+            childColumns = ["category_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("user_id"), Index("category_id")]
+)
 data class Expense(
+    @PrimaryKey(autoGenerate = true)
     val id: Long = 0L,
+    @ColumnInfo(name = "user_id")
     val userId: Long,
+    @ColumnInfo(name = "category_id")
     val categoryId: Long,
+    @ColumnInfo(name = "name")
     val name: String,
+    @ColumnInfo(name = "amount")
     val amount: Double,
+    @ColumnInfo(name = "date_iso")
     val dateIso: String,
+    @ColumnInfo(name = "receipt_uri")
     val receiptUri: String? = null,
+    @ColumnInfo(name = "created_at")
     val createdAtEpochMillis: Long = System.currentTimeMillis()
 ) {
+    @delegate:Ignore
     val localDate: LocalDate by lazy { LocalDate.parse(dateIso) }
 }

--- a/app/src/main/java/com/example/oinkonomics/data/User.kt
+++ b/app/src/main/java/com/example/oinkonomics/data/User.kt
@@ -1,0 +1,19 @@
+package com.example.oinkonomics.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "users",
+    indices = [Index(value = ["username"], unique = true)]
+)
+data class User(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "username")
+    val username: String,
+    @ColumnInfo(name = "password_hash")
+    val passwordHash: String
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ lifecycleRuntimeKtx = "2.9.4"
 navigationFragmentKtx = "2.9.5"
 navigationUiKtx = "2.9.5"
 kotlinxCoroutines = "1.9.0"
+room = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,9 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- replace the custom SQLiteOpenHelper with a Room database and DAO to persist users, categories, and expenses
- annotate the data models as Room entities and introduce a dedicated User entity
- add the required Room dependencies and update the repository to call the new DAO APIs

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68dff93b0ba48333bcf62b0c90b35763