### PR TITLE
Fix expense creation failure when user session is missing

### DIFF
--- a/app/src/main/java/com/example/oinkonomics/data/MissingUserException.kt
+++ b/app/src/main/java/com/example/oinkonomics/data/MissingUserException.kt
@@ -1,0 +1,5 @@
+package com.example.oinkonomics.data
+
+class MissingUserException : IllegalStateException(
+    "Your account information could not be found. Please sign in again."
+)

--- a/app/src/main/java/com/example/oinkonomics/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/oinkonomics/ui/home/HomeFragment.kt
@@ -134,6 +134,13 @@ class HomeFragment : Fragment() {
                     if (state.errorMessage != null) {
                         Toast.makeText(requireContext(), state.errorMessage, Toast.LENGTH_SHORT).show()
                     }
+                    if (state.sessionExpired) {
+                        sessionManager.clearSession()
+                        startActivity(Intent(requireContext(), AuthActivity::class.java))
+                        viewModel.onSessionInvalidHandled()
+                        requireActivity().finish()
+                        return@collect
+                    }
                     updateHeader(state.totalSpent, state.totalBudget)
                     renderExpenses(state.expenses, state.categories)
                 }


### PR DESCRIPTION
## Summary
- preserve the users table during database upgrades and add a direct user existence check
- throw a dedicated MissingUserException from the repository whenever a session references a missing user
- surface the expired session state in the Home and Dashboard flows so the user is signed out and redirected

## Testing
- not run (environment lacks network access for Gradle)


------
https://chatgpt.com/codex/tasks/task_e_68e00518913c8333b80fa0c89a23ef9d